### PR TITLE
Add separator parameter

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -102,6 +102,20 @@ If you like to use another marker than `[ci skip]` for skipping CI build then us
 
 In this case when commit message contains `banana banana` then action will be skipped.
 
+=== Multiple filters
+
+If you want to use multiple filters at once, it's possible to separate them with the `separator` input.
+
+[source,yaml]
+----
+[...]
+      - uses: mstachniuk/ci-skip@v1
+        with:
+          commit-filter: 'banana;orange'
+					separator: ';'
+[...]
+----
+
 == Google Chrome Extension
 
 If you would decide on merge to skip or not an action the https://github.com/mstachniuk/shipkit-chrome-extension[shipkit-chrome-extension] can be helpful.

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -112,7 +112,7 @@ If you want to use multiple filters at once, it's possible to separate them with
       - uses: mstachniuk/ci-skip@v1
         with:
           commit-filter: 'banana;orange'
-					separator: ';'
+          separator: ';'
 [...]
 ----
 

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,12 @@ inputs:
     description: 'Sets the text in commit messages when skip the action. Default: [ci skip]'
     required: false
     default: '[ci skip]'
+  separator:
+    description: 'Sets the commit filter separator in case multiple filters are set.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/script.sh "${{ inputs.fail-fast }}" "${{ inputs.exit-code }}" "${{ inputs.commit-filter }}"
+    - run: $GITHUB_ACTION_PATH/script.sh "${{ inputs.fail-fast }}" "${{ inputs.exit-code }}" "${{ inputs.commit-filter }}" "${{ inputs.separator }}"
       shell: bash

--- a/test/fail-fast.bats
+++ b/test/fail-fast.bats
@@ -60,3 +60,33 @@ load checkout_helper
   echo "$output"
   [ "$status" -eq 22 ]
 }
+
+@test "should fail fast and return 22 exit code with custom separator" {
+  mydir="repo-commit-contains-ci-skip-5"
+  # Contains `Test commit [ci skip];[skip ci]` in message subject
+  checkoutRevisionAndCopyScript 'b5634847ae9760ee46cf8a1c928cd8689a821744' "$mydir"
+  export GITHUB_ENV=foo.txt;
+
+  run "$BATS_TMPDIR/$mydir/ci-skip/script.sh" "true" "22" "[skip ci];[ci skip];[skip gha]" ";"
+
+  actual=$(cat foo.txt | sed ':a;N;$!ba;s/\n/,/g') # replace new line with coma
+  echo "Output:"
+  echo "$output"
+  echo "GITHUB_ENV: $actual"
+  [ "$status" -eq 22 ]
+}
+
+@test "should not fail fast and return 0 exit code without custom separator" {
+  mydir="repo-commit-contains-ci-skip-6"
+  # Contains `Test commit [ci skip];[skip ci]` in message subject
+  checkoutRevisionAndCopyScript 'b5634847ae9760ee46cf8a1c928cd8689a821744' "$mydir"
+  export GITHUB_ENV=foo.txt;
+
+  run "$BATS_TMPDIR/$mydir/ci-skip/script.sh" "true" "22" "[skip ci];[ci skip];[skip gha]"
+
+  actual=$(cat foo.txt | sed ':a;N;$!ba;s/\n/,/g') # replace new line with coma
+  echo "Output:"
+  echo "$output"
+  echo "GITHUB_ENV: $actual"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
This PR adds a `separator` parameter to allow for multiple filters. With something like *(PR syntax)*:

```
      - uses: GuillaumeFavelier/ci-skip@enh/separator
        with:
          commit-filter: '[skip ci];[ci skip];[skip github]'
          separator: ';'
```